### PR TITLE
workflows: Update azcopy_download/upload

### DIFF
--- a/.github/workflows/ci-test-interop.yaml
+++ b/.github/workflows/ci-test-interop.yaml
@@ -176,7 +176,7 @@ jobs:
           pattern: "${{ steps.describe.outputs.pkg_version }}"
 
       - name: Download DKMS Package from Azure storage
-        uses: ./ci-libs/github_actions/azure/azcopy_download
+        uses: ./ci-libs/github_actions/azure/azcopy_download_sync
         with:
           connection-string: ${{ secrets.AZ_SAS_TOK }}
           src: "${{ steps.describe.outputs.azure_dest }}/${{ steps.artifact.outputs.latest }}"

--- a/.github/workflows/package-dkms.yaml
+++ b/.github/workflows/package-dkms.yaml
@@ -160,7 +160,7 @@ jobs:
 
       # --- UPLOAD DKMS PACKAGE TO AZURE ---
       - name: Upload to DKMS Package to Azure storage
-        uses: ./ci-libs/github_actions/azure/azcopy_upload
+        uses: ./ci-libs/github_actions/azure/azcopy_upload_sync
         with:
           connection-string: ${{ secrets.AZ_SAS_TOK }}
           src: '${{ steps.build_dest.outputs.dkms_bin_path }}'


### PR DESCRIPTION
Replaced all `azcopy_download` and `azcopy_upload` with
`azcopy_download_sync` and `azcopy_upload_sync` in workflows and
actions.
This was done to eliminate Azure upload or download issues so the
CI infrastructure can be expanded to Nanjing.