### PR TITLE
compat: add support for RHEL 9 kernel >=5.14.0-305

### DIFF
--- a/src/nfp_devlink.c
+++ b/src/nfp_devlink.c
@@ -340,7 +340,7 @@ nfp_devlink_info_get(struct devlink *devlink, struct devlink_info_req *req,
 	char *buf = NULL;
 	int err;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 	err = devlink_info_driver_name_put(req, "nfp");
 	if (err)
 		return err;
@@ -461,7 +461,7 @@ int nfp_devlink_port_register(struct nfp_app *app, struct nfp_port *port)
 	const u8 *serial;
 	int ret;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_GE(6, 2)) || (RHEL_RELEASE_GE(9, 305, 0, 0))
 	SET_NETDEV_DEVLINK_PORT(port->netdev, &port->dl_port);
 #endif
 
@@ -494,7 +494,7 @@ void nfp_devlink_port_unregister(struct nfp_port *port)
 	devl_port_unregister(&port->dl_port);
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 void nfp_devlink_port_type_eth_set(struct nfp_port *port)
 {
 	devlink_port_type_eth_set(&port->dl_port, port->netdev);

--- a/src/nfp_net_common.c
+++ b/src/nfp_net_common.c
@@ -2456,7 +2456,8 @@ const struct net_device_ops nfp_nfd3_netdev_ops = {
 	.ndo_get_port_parent_id	= nfp_port_get_port_parent_id,
 #endif
 #ifdef CONFIG_NFP_NET_PF
-#if VER_NON_RHEL_GE(5, 2) && VER_NON_RHEL_LT(6, 2) || VER_RHEL_GE(8, 2)
+#if (VER_NON_RHEL_GE(5, 2) && VER_NON_RHEL_LT(6, 2)) || \
+		(VER_RHEL_GE(8, 2) && RHEL_RELEASE_LT(9, 305, 0, 0))
 	.ndo_get_devlink_port	= nfp_devlink_get_devlink_port,
 #elif VER_NON_RHEL_GE(5, 1) && VER_NON_RHEL_LT(5, 2)
 	.ndo_get_devlink	= nfp_devlink_get_devlink,
@@ -2548,7 +2549,8 @@ const struct net_device_ops nfp_nfdk_netdev_ops = {
 	.ndo_get_port_parent_id	= nfp_port_get_port_parent_id,
 #endif
 #ifdef CONFIG_NFP_NET_PF
-#if VER_NON_RHEL_GE(5, 2) && VER_NON_RHEL_LT(6, 2) || VER_RHEL_GE(8, 2)
+#if (VER_NON_RHEL_GE(5, 2) && VER_NON_RHEL_LT(6, 2)) || \
+		(VER_RHEL_GE(8, 2) && RHEL_RELEASE_LT(9, 305, 0, 0))
 	.ndo_get_devlink_port	= nfp_devlink_get_devlink_port,
 #elif VER_NON_RHEL_GE(5, 1) && VER_NON_RHEL_LT(5, 2)
 	.ndo_get_devlink	= nfp_devlink_get_devlink,

--- a/src/nfp_net_main.c
+++ b/src/nfp_net_main.c
@@ -156,7 +156,7 @@ nfp_net_pf_init_vnic(struct nfp_pf *pf, struct nfp_net *nn, unsigned int id)
 
 	nfp_net_debugfs_vnic_add(nn, pf->ddir);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 	if (nn->port)
 		nfp_devlink_port_type_eth_set(nn->port);
 #endif
@@ -166,7 +166,7 @@ nfp_net_pf_init_vnic(struct nfp_pf *pf, struct nfp_net *nn, unsigned int id)
 	if (nfp_net_is_data_vnic(nn)) {
 		err = nfp_app_vnic_init(pf->app, nn);
 		if (err)
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 			goto err_devlink_port_type_clean;
 #else
 			goto err_debugfs_vnic_clean;
@@ -175,7 +175,7 @@ nfp_net_pf_init_vnic(struct nfp_pf *pf, struct nfp_net *nn, unsigned int id)
 
 	return 0;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 err_devlink_port_type_clean:
 	if (nn->port)
 		nfp_devlink_port_type_clear(nn->port);
@@ -230,7 +230,7 @@ static void nfp_net_pf_clean_vnic(struct nfp_pf *pf, struct nfp_net *nn)
 {
 	if (nfp_net_is_data_vnic(nn))
 		nfp_app_vnic_clean(pf->app, nn);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 	if (nn->port)
 		nfp_devlink_port_type_clear(nn->port);
 #endif

--- a/src/nfp_port.h
+++ b/src/nfp_port.h
@@ -159,7 +159,7 @@ int nfp_net_refresh_port_table_sync(struct nfp_pf *pf);
 
 int nfp_devlink_port_register(struct nfp_app *app, struct nfp_port *port);
 void nfp_devlink_port_unregister(struct nfp_port *port);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (VER_NON_RHEL_LT(6, 2)) || (RHEL_RELEASE_LT(9, 305, 0, 0))
 void nfp_devlink_port_type_eth_set(struct nfp_port *port);
 void nfp_devlink_port_type_clear(struct nfp_port *port);
 #endif


### PR DESCRIPTION
The release version conditionals are updated to allow the driver to compile against CentOS 9 Stream kernels >= 5.14.0-305.