### PR TITLE
nfp: flower: use private nfp_fl_lock replace rtnl_lock

### DIFF
--- a/src/flower/cmsg.c
+++ b/src/flower/cmsg.c
@@ -210,6 +210,7 @@ nfp_flower_cmsg_merge_hint_rx(struct nfp_app *app, struct sk_buff *skb)
 	unsigned int msg_len = nfp_flower_cmsg_get_data_len(skb);
 	struct nfp_flower_cmsg_merge_hint *msg;
 	struct nfp_fl_payload *sub_flows[2];
+	struct nfp_flower_priv *priv;
 	int err, i, flow_cnt;
 
 	msg = nfp_flower_cmsg_get_data(skb);
@@ -228,7 +229,9 @@ nfp_flower_cmsg_merge_hint_rx(struct nfp_app *app, struct sk_buff *skb)
 		return;
 	}
 
-	rtnl_lock();
+	priv = app->priv;
+
+	mutex_lock(&priv->nfp_fl_lock);
 	for (i = 0; i < flow_cnt; i++) {
 		u32 ctx = be32_to_cpu(msg->flow[i].host_ctx);
 
@@ -245,7 +248,7 @@ nfp_flower_cmsg_merge_hint_rx(struct nfp_app *app, struct sk_buff *skb)
 		nfp_flower_cmsg_warn(app, "Flow merge memory fail.\n");
 
 err_rtnl_unlock:
-	rtnl_unlock();
+	mutex_unlock(&priv->nfp_fl_lock);
 }
 
 static void

--- a/src/flower/conntrack.c
+++ b/src/flower/conntrack.c
@@ -2110,8 +2110,6 @@ nfp_fl_ct_offload_nft_flow(struct nfp_fl_ct_zone_entry *zt, struct flow_cls_offl
 	struct nfp_fl_ct_flow_entry *ct_entry;
 	struct netlink_ext_ack *extack = NULL;
 
-	ASSERT_RTNL();
-
 	extack = flow->common.extack;
 	switch (flow->command) {
 	case FLOW_CLS_REPLACE:
@@ -2154,9 +2152,13 @@ int nfp_fl_ct_handle_nft_flow(enum tc_setup_type type, void *type_data, void *cb
 
 	switch (type) {
 	case TC_SETUP_CLSFLOWER:
-		rtnl_lock();
+		while (!mutex_trylock(&zt->priv->nfp_fl_lock)) {
+			if (!zt->nft) /* avoid deadlock */
+				return err;
+			msleep(20);
+		}
 		err = nfp_fl_ct_offload_nft_flow(zt, flow);
-		rtnl_unlock();
+		mutex_unlock(&zt->priv->nfp_fl_lock);
 		break;
 	default:
 		return -EOPNOTSUPP;
@@ -2184,6 +2186,9 @@ int nfp_fl_ct_del_flow(struct nfp_fl_ct_map_entry *ct_map_ent)
 	struct nfp_fl_ct_flow_entry *ct_entry;
 	struct nfp_fl_ct_zone_entry *zt;
 	struct rhashtable *m_table;
+#if IS_ENABLED(CONFIG_NET_ACT_CT)
+	struct nf_flowtable *nft;
+#endif
 
 	if (!ct_map_ent)
 		return -ENOENT;
@@ -2212,15 +2217,16 @@ int nfp_fl_ct_del_flow(struct nfp_fl_ct_map_entry *ct_map_ent)
 		 * save this state and delete the callback later since the
 		 * nft table would already have been freed at that time.
 		 */
-		if (!zt->pre_ct_count) {
-#if VER_NON_RHEL_LT(5, 14) || VER_RHEL_LT(8, 5)
-			rtnl_unlock(); /* avoid deadlock */
-			nf_flow_table_offload_del_cb(zt->nft,
+		if (!zt->pre_ct_count && zt->nft) {
+#if IS_ENABLED(CONFIG_NET_ACT_CT)
+			nft = zt->nft;
+			zt->nft = NULL; /* avoid deadlock */
+			nf_flow_table_offload_del_cb(nft,
 						     nfp_fl_ct_handle_nft_flow,
 						     zt);
-			rtnl_lock();
-#endif
+#else
 			zt->nft = NULL;
+#endif
 			nfp_fl_ct_clean_nft_entries(zt);
 		}
 		break;

--- a/src/flower/main.h
+++ b/src/flower/main.h
@@ -346,6 +346,7 @@ struct nfp_flower_priv {
 	struct list_head predt_list;
 	struct rhashtable neigh_table;
 	spinlock_t predt_lock; /* Lock to serialise predt/neigh table updates */
+	struct mutex nfp_fl_lock; /* Protect the flow operation */
 };
 
 /**

--- a/src/flower/metadata.c
+++ b/src/flower/metadata.c
@@ -541,6 +541,8 @@ int nfp_flower_metadata_init(struct nfp_app *app, u64 host_ctx_count,
 	if (err)
 		goto err_free_stats_ctx_table;
 
+	mutex_init(&priv->nfp_fl_lock);
+
 #if VER_NON_RHEL_GE(5, 9) || VER_RHEL_GE(8, 3)
 	err = rhashtable_init(&priv->ct_zone_table, &nfp_zone_table_params);
 	if (err)


### PR DESCRIPTION
OpenEuler22.03, kernel6.1.0 enable CONFIG_NET_ACT_CT macro recompilation, failed to compile nf_flow_table_offload_del_cb resulted in rmmod crashing.

Replace 'VERNON_RHEL_LT (5,14) | | VER_RHEL_LT (8,5)' with 'ISENABLED (CONFIG_SET_ACT_CT)',can be compatible with compiling kernel issues.

Replace rtnl_lock with the internal nfp lock nfp_fl_lock to avoid the issue of rtnl_lock sometimes failing.