### PR TITLE
Wip cicd 2121 remove safe git directory step

### DIFF
--- a/.github/workflows/ci-test-interop.yaml
+++ b/.github/workflows/ci-test-interop.yaml
@@ -105,9 +105,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GHUB_TOKEN }}
 
-      - name: Add nfp-drv-kmods-private to git safe directory list
-        run: git config --global --add safe.directory `pwd`
-
       - name: Clone ci-libs (for other GH actions)
         uses: Corigine/ci-libs/github_actions/utilities/checkout_corigine@main
         with:

--- a/.github/workflows/ci-test-interop.yaml
+++ b/.github/workflows/ci-test-interop.yaml
@@ -100,15 +100,16 @@ jobs:
 
       # --- CLONE REPOSITORIES ---
       - name: Checkout nfp driver kmods repo
-        uses: actions/checkout@v3
+        uses: Corigine/ci-libs/github_actions/utilities/checkout_corigine@main
         with:
           fetch-depth: 0
+          token: ${{ secrets.GHUB_TOKEN }}
 
       - name: Add nfp-drv-kmods-private to git safe directory list
         run: git config --global --add safe.directory `pwd`
 
       - name: Clone ci-libs (for other GH actions)
-        uses: actions/checkout@v3
+        uses: Corigine/ci-libs/github_actions/utilities/checkout_corigine@main
         with:
           repository: Corigine/ci-libs
           token: ${{ secrets.GHUB_TOKEN }}

--- a/.github/workflows/ci-test-interop.yaml
+++ b/.github/workflows/ci-test-interop.yaml
@@ -118,98 +118,98 @@ jobs:
           tar -xvf /tmp/downloadazcopy-v10-linux.tgz -C /tmp/
           sudo cp /tmp/azcopy_linux_amd64_*/azcopy /usr/bin/
 
-      # --- COLLECT INFO AND DOWNLOAD PACKAGE ---
-      - name: Collect package information
-        id: describe
-        shell: bash
-        run: |-2
-          case "$DISTRO" in
-            "ubuntu"*)
-              BINARY_TYPE="deb"
-              ;;
-            "centos"* | "rockylinux"* | "almalinux"*)
-              BINARY_TYPE="rpm"
-              ;;
-            *)
-              BINARY_TYPE="unknown"
-              ;;
-          esac
+      # # --- COLLECT INFO AND DOWNLOAD PACKAGE ---
+      # - name: Collect package information
+      #   id: describe
+      #   shell: bash
+      #   run: |-2
+      #     case "$DISTRO" in
+      #       "ubuntu"*)
+      #         BINARY_TYPE="deb"
+      #         ;;
+      #       "centos"* | "rockylinux"* | "almalinux"*)
+      #         BINARY_TYPE="rpm"
+      #         ;;
+      #       *)
+      #         BINARY_TYPE="unknown"
+      #         ;;
+      #     esac
 
-          PACKAGE_NAME=$(.github/scripts/describe-head.sh --pkg_name)
-          PACKAGE_VERSION=$(.github/scripts/describe-head.sh --pkg_ver)
+      #     PACKAGE_NAME=$(.github/scripts/describe-head.sh --pkg_name)
+      #     PACKAGE_VERSION=$(.github/scripts/describe-head.sh --pkg_ver)
 
-          echo "pkg_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "pkg_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
-          echo "binary_type=${BINARY_TYPE}" >> $GITHUB_OUTPUT
+      #     echo "pkg_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+      #     echo "pkg_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+      #     echo "binary_type=${BINARY_TYPE}" >> $GITHUB_OUTPUT
 
-          # DEFAULT_BRANCH defaults to public-main, but can be used to denote
-          # other long-running branches for separate interim releases
-          echo "default_branch=${DEFAULT_BRANCH}" >> $GITHUB_OUTPUT
+      #     # DEFAULT_BRANCH defaults to public-main, but can be used to denote
+      #     # other long-running branches for separate interim releases
+      #     echo "default_branch=${DEFAULT_BRANCH}" >> $GITHUB_OUTPUT
 
-          # If the default branch is not 'public-main', append the branch name,
-          # without 'wip-', to the upload destination
-          if [ ! "$DEFAULT_BRANCH" = "public-main" ]; then
-            DST_SUFFIX=".${DEFAULT_BRANCH#wip-}"
-          fi
-          case $HEAD_REF in
-            "release-"*)
-              TARGET_FOLDER=${HEAD_REF#*-}
-              TARGET_FOLDER=${TARGET_FOLDER:0:5}
-              AZURE_PATH="binaries/nfp-drv-dkms/releases${DST_SUFFIX}/${TARGET_FOLDER}"
-              ;;
-            "prerelease-"*)
-              TARGET_FOLDER=${HEAD_REF#*-}
-              TARGET_FOLDER=${TARGET_FOLDER:0:5}
-              AZURE_PATH="binaries/nfp-drv-dkms/prereleases${DST_SUFFIX}/${TARGET_FOLDER}"
-              ;;
-            "${DEFAULT_BRANCH}")
-              AZURE_PATH="binaries/nfp-drv-dkms/interim${DST_SUFFIX}/${PACKAGE_NAME}"
-              ;;
-            *)
-              AZURE_PATH="tmp/nfp_drv_dkms_builds${DST_SUFFIX}"
-              AZURE_PATH="$AZURE_PATH/${{ github.actor }}"
-              ;;
-          esac
+      #     # If the default branch is not 'public-main', append the branch name,
+      #     # without 'wip-', to the upload destination
+      #     if [ ! "$DEFAULT_BRANCH" = "public-main" ]; then
+      #       DST_SUFFIX=".${DEFAULT_BRANCH#wip-}"
+      #     fi
+      #     case $HEAD_REF in
+      #       "release-"*)
+      #         TARGET_FOLDER=${HEAD_REF#*-}
+      #         TARGET_FOLDER=${TARGET_FOLDER:0:5}
+      #         AZURE_PATH="binaries/nfp-drv-dkms/releases${DST_SUFFIX}/${TARGET_FOLDER}"
+      #         ;;
+      #       "prerelease-"*)
+      #         TARGET_FOLDER=${HEAD_REF#*-}
+      #         TARGET_FOLDER=${TARGET_FOLDER:0:5}
+      #         AZURE_PATH="binaries/nfp-drv-dkms/prereleases${DST_SUFFIX}/${TARGET_FOLDER}"
+      #         ;;
+      #       "${DEFAULT_BRANCH}")
+      #         AZURE_PATH="binaries/nfp-drv-dkms/interim${DST_SUFFIX}/${PACKAGE_NAME}"
+      #         ;;
+      #       *)
+      #         AZURE_PATH="tmp/nfp_drv_dkms_builds${DST_SUFFIX}"
+      #         AZURE_PATH="$AZURE_PATH/${{ github.actor }}"
+      #         ;;
+      #     esac
 
-          echo "azure_dest=$(echo "${AZURE_PATH}")" >> $GITHUB_OUTPUT
-        env:
-          DISTRO: ${{ matrix.distro }}
-          DEFAULT_BRANCH: public-main
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      #     echo "azure_dest=$(echo "${AZURE_PATH}")" >> $GITHUB_OUTPUT
+      #   env:
+      #     DISTRO: ${{ matrix.distro }}
+      #     DEFAULT_BRANCH: public-main
+      #     HEAD_REF: ${{ github.head_ref || github.ref_name }}
 
-      - name: Find package name from Azure
-        uses: ./ci-libs/github_actions/azure/azcopy_list
-        id: artifact
-        with:
-          connection-string: ${{ secrets.AZ_SAS_TOK }}
-          src: ${{ steps.describe.outputs.azure_dest }}
-          pattern: "${{ steps.describe.outputs.pkg_version }}.*${{ steps.describe.outputs.binary_type }}"
+      # - name: Find package name from Azure
+      #   uses: ./ci-libs/github_actions/azure/azcopy_list
+      #   id: artifact
+      #   with:
+      #     connection-string: ${{ secrets.AZ_SAS_TOK }}
+      #     src: ${{ steps.describe.outputs.azure_dest }}
+      #     pattern: "${{ steps.describe.outputs.pkg_version }}.*${{ steps.describe.outputs.binary_type }}"
 
-      - name: Download DKMS Package from Azure storage
-        uses: ./ci-libs/github_actions/azure/azcopy_download_sync
-        with:
-          connection-string: ${{ secrets.AZ_SAS_TOK }}
-          src: "${{ steps.describe.outputs.azure_dest }}/${{ steps.artifact.outputs.latest }}"
-          dst: "./${{ steps.describe.outputs.pkg_name }}.${{ steps.describe.outputs.binary_type }}"
+      # - name: Download DKMS Package from Azure storage
+      #   uses: ./ci-libs/github_actions/azure/azcopy_download_sync
+      #   with:
+      #     connection-string: ${{ secrets.AZ_SAS_TOK }}
+      #     src: "${{ steps.describe.outputs.azure_dest }}/${{ steps.artifact.outputs.latest }}"
+      #     dst: "./${{ steps.describe.outputs.pkg_name }}.${{ steps.describe.outputs.binary_type }}"
 
-      # --- INSTALL DKMS PACKAGE ---
-      - name: APT | Install DKMS package
-        if: "contains(matrix.distro, 'ubuntu')"
-        run: dpkg -i ${DKMS_PACKAGE}
-        env:
-          DKMS_PACKAGE: "${{ steps.describe.outputs.pkg_name }}.deb"
+      # # --- INSTALL DKMS PACKAGE ---
+      # - name: APT | Install DKMS package
+      #   if: "contains(matrix.distro, 'ubuntu')"
+      #   run: dpkg -i ${DKMS_PACKAGE}
+      #   env:
+      #     DKMS_PACKAGE: "${{ steps.describe.outputs.pkg_name }}.deb"
 
-      - name: YUM | Install DKMS package
-        if: matrix.distro == 'centos:7'
-        run: yum -y install ${DKMS_PACKAGE}
-        env:
-          DKMS_PACKAGE: "${{ steps.describe.outputs.pkg_name }}.rpm"
+      # - name: YUM | Install DKMS package
+      #   if: matrix.distro == 'centos:7'
+      #   run: yum -y install ${DKMS_PACKAGE}
+      #   env:
+      #     DKMS_PACKAGE: "${{ steps.describe.outputs.pkg_name }}.rpm"
 
-      - name: DNF | Install DKMS package
-        if: >-
-          ${{ contains(matrix.distro, 'centos:8') ||
-          contains(matrix.distro, 'rockylinux') ||
-          contains(matrix.distro, 'almalinux') }}
-        run: dnf -y install ${DKMS_PACKAGE}
-        env:
-          DKMS_PACKAGE: "${{ steps.describe.outputs.pkg_name }}.rpm"
+      # - name: DNF | Install DKMS package
+      #   if: >-
+      #     ${{ contains(matrix.distro, 'centos:8') ||
+      #     contains(matrix.distro, 'rockylinux') ||
+      #     contains(matrix.distro, 'almalinux') }}
+      #   run: dnf -y install ${DKMS_PACKAGE}
+      #   env:
+      #     DKMS_PACKAGE: "${{ steps.describe.outputs.pkg_name }}.rpm"

--- a/.github/workflows/package-dkms.yaml
+++ b/.github/workflows/package-dkms.yaml
@@ -63,24 +63,6 @@ jobs:
           dnf install -y --enablerepo=powertools
           git wget sudo gcc make automake dkms rpm-build findutils
 
-      - name: Clean up the working directory
-        run: find -delete
-
-      - name: Add nfp-drv-kmods-private to git safe directory list
-        run: git config --global --add safe.directory `pwd`
-
-      # The commands in docker is run as root, with UUID of 0. The
-      # ownwership of the working directory is under a different UUID, since
-      # it is mounted from the host. This causes "dubious ownership" issues
-      # with git, and for some reason the usual global .gitconfig setting does
-      # not take effect. To fix this just change the ownership of the
-      # directory. This is cleaned up again at the end of the run, so the
-      # permissions is not expected to cause any problems on the github-runner
-      # side
-      - name: Update the ownership of the working directory
-        run: |
-          chown -R 0:0 $(pwd)
-
       # --- CLONE REPOSITORIES ---
       - name: Checkout nfp driver kmods repo
         uses: Corigine/ci-libs/github_actions/utilities/checkout_corigine@main

--- a/.github/workflows/package-dkms.yaml
+++ b/.github/workflows/package-dkms.yaml
@@ -76,106 +76,106 @@ jobs:
           tar -xvf /tmp/downloadazcopy-v10-linux.tgz -C /tmp/
           sudo cp /tmp/azcopy_linux_amd64_*/azcopy /usr/bin/
 
-      # --- COLLECT BUILD INFORMATION ---
-      - name: Collect metadata
-        id: describe
-        run: |-2
-          case "$DISTRO" in
-            'ubuntu:20.04')
-              BINARY_TYPE="deb"
-              ;;
-            'rockylinux:8.5')
-              BINARY_TYPE="rpm"
-              ;;
-            *)
-              BINARY_TYPE="unknown"
-              ;;
-          esac
+      # # --- COLLECT BUILD INFORMATION ---
+      # - name: Collect metadata
+      #   id: describe
+      #   run: |-2
+      #     case "$DISTRO" in
+      #       'ubuntu:20.04')
+      #         BINARY_TYPE="deb"
+      #         ;;
+      #       'rockylinux:8.5')
+      #         BINARY_TYPE="rpm"
+      #         ;;
+      #       *)
+      #         BINARY_TYPE="unknown"
+      #         ;;
+      #     esac
 
-          PACKAGE_NAME=$(.github/scripts/describe-head.sh --pkg_name)
+      #     PACKAGE_NAME=$(.github/scripts/describe-head.sh --pkg_name)
 
-          echo "pkg_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "binary_type=${BINARY_TYPE}" >> $GITHUB_OUTPUT
+      #     echo "pkg_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+      #     echo "binary_type=${BINARY_TYPE}" >> $GITHUB_OUTPUT
 
-          # DEFAULT_BRANCH defaults to public-main, but can be used to denote
-          # other long-running branches for separate interim releases
-          echo "default_branch=${DEFAULT_BRANCH}" >> $GITHUB_OUTPUT
-        env:
-          DISTRO: ${{ matrix.distro }}
-          DEFAULT_BRANCH: public-main
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      #     # DEFAULT_BRANCH defaults to public-main, but can be used to denote
+      #     # other long-running branches for separate interim releases
+      #     echo "default_branch=${DEFAULT_BRANCH}" >> $GITHUB_OUTPUT
+      #   env:
+      #     DISTRO: ${{ matrix.distro }}
+      #     DEFAULT_BRANCH: public-main
+      #     HEAD_REF: ${{ github.head_ref || github.ref_name }}
 
-      # --- BUILD DKMS PACKAGE ---
-      - name: Ubuntu | Build DEB DKMS package
-        if: matrix.distro == 'ubuntu:20.04'
-        run: sudo -E .github/scripts/package-dkms.sh -t d
-        env:
-          DEFAULT_BRANCH: ${{steps.describe.outputs.default_branch}}
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      # # --- BUILD DKMS PACKAGE ---
+      # - name: Ubuntu | Build DEB DKMS package
+      #   if: matrix.distro == 'ubuntu:20.04'
+      #   run: sudo -E .github/scripts/package-dkms.sh -t d
+      #   env:
+      #     DEFAULT_BRANCH: ${{steps.describe.outputs.default_branch}}
+      #     HEAD_REF: ${{ github.head_ref || github.ref_name }}
 
-      - name: CentOS | Build RPM DKMS package
-        if: matrix.distro == 'rockylinux:8.5'
-        run: sudo -E .github/scripts/package-dkms.sh -t r
-        env:
-          DEFAULT_BRANCH: ${{steps.describe.outputs.default_branch}}
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      # - name: CentOS | Build RPM DKMS package
+      #   if: matrix.distro == 'rockylinux:8.5'
+      #   run: sudo -E .github/scripts/package-dkms.sh -t r
+      #   env:
+      #     DEFAULT_BRANCH: ${{steps.describe.outputs.default_branch}}
+      #     HEAD_REF: ${{ github.head_ref || github.ref_name }}
 
-      - name: Prepare environment for upload
-        id: build_dest
-        shell: bash
-        run: |
-          DATE="$(date -u +%Y.%m.%d)"
+      # - name: Prepare environment for upload
+      #   id: build_dest
+      #   shell: bash
+      #   run: |
+      #     DATE="$(date -u +%Y.%m.%d)"
 
-          temp_dir=$(pwd)
-          cd ${BIN_TYPE}/${BIN_PKG_NAME}
-          DKMS_PKG_NAME=$(ls ${BIN_PKG_NAME}-dkms*.${BIN_TYPE})
-          cd $temp_dir
+      #     temp_dir=$(pwd)
+      #     cd ${BIN_TYPE}/${BIN_PKG_NAME}
+      #     DKMS_PKG_NAME=$(ls ${BIN_PKG_NAME}-dkms*.${BIN_TYPE})
+      #     cd $temp_dir
 
-          echo "${BIN_TYPE}/${BIN_PKG_NAME}/${DKMS_PKG_NAME}"
-          echo "${BIN_PKG_NAME}"
+      #     echo "${BIN_TYPE}/${BIN_PKG_NAME}/${DKMS_PKG_NAME}"
+      #     echo "${BIN_PKG_NAME}"
 
-          # If the default branch is not 'public-main', append the branch name,
-          # without 'wip-', to the upload destination
-          if [ ! "$DEFAULT_BRANCH" = "public-main" ]; then
-            DST_SUFFIX=".${DEFAULT_BRANCH#wip-}"
-          fi
-          case $HEAD_REF in
-            "release-"*)
-              TARGET_FOLDER=${HEAD_REF#*-}
-              TARGET_FOLDER=${TARGET_FOLDER:0:5}
-              AZURE_PATH="binaries/nfp-drv-dkms/releases${DST_SUFFIX}/${TARGET_FOLDER}"
-              ;;
-            "prerelease-"*)
-              TARGET_FOLDER=${HEAD_REF#*-}
-              TARGET_FOLDER=${TARGET_FOLDER:0:5}
-              AZURE_PATH="binaries/nfp-drv-dkms/prereleases${DST_SUFFIX}/${TARGET_FOLDER}"
-              ;;
-            "${DEFAULT_BRANCH}")
-              AZURE_PATH="binaries/nfp-drv-dkms/interim${DST_SUFFIX}/${BIN_PKG_NAME}"
-              ;;
-            *)
-              AZURE_PATH="tmp/nfp_drv_dkms_builds${DST_SUFFIX}"
-              AZURE_PATH="$AZURE_PATH/${{ github.actor }}/${DATE}"
-              ;;
-          esac
+      #     # If the default branch is not 'public-main', append the branch name,
+      #     # without 'wip-', to the upload destination
+      #     if [ ! "$DEFAULT_BRANCH" = "public-main" ]; then
+      #       DST_SUFFIX=".${DEFAULT_BRANCH#wip-}"
+      #     fi
+      #     case $HEAD_REF in
+      #       "release-"*)
+      #         TARGET_FOLDER=${HEAD_REF#*-}
+      #         TARGET_FOLDER=${TARGET_FOLDER:0:5}
+      #         AZURE_PATH="binaries/nfp-drv-dkms/releases${DST_SUFFIX}/${TARGET_FOLDER}"
+      #         ;;
+      #       "prerelease-"*)
+      #         TARGET_FOLDER=${HEAD_REF#*-}
+      #         TARGET_FOLDER=${TARGET_FOLDER:0:5}
+      #         AZURE_PATH="binaries/nfp-drv-dkms/prereleases${DST_SUFFIX}/${TARGET_FOLDER}"
+      #         ;;
+      #       "${DEFAULT_BRANCH}")
+      #         AZURE_PATH="binaries/nfp-drv-dkms/interim${DST_SUFFIX}/${BIN_PKG_NAME}"
+      #         ;;
+      #       *)
+      #         AZURE_PATH="tmp/nfp_drv_dkms_builds${DST_SUFFIX}"
+      #         AZURE_PATH="$AZURE_PATH/${{ github.actor }}/${DATE}"
+      #         ;;
+      #     esac
 
-          AZURE_DEST=$(echo "${AZURE_PATH}/${BIN_TYPE}")
-          echo "dkms_bin_path=$(echo "${BIN_TYPE}/${BIN_PKG_NAME}/${DKMS_PKG_NAME}")" >> $GITHUB_OUTPUT
-          echo "azure_dest=${AZURE_DEST}" >> $GITHUB_OUTPUT
-        env:
-          DEFAULT_BRANCH: ${{steps.describe.outputs.default_branch}}
-          BIN_TYPE: '${{ steps.describe.outputs.binary_type }}'
-          BIN_PKG_NAME: '${{ steps.describe.outputs.pkg_name }}'
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      #     AZURE_DEST=$(echo "${AZURE_PATH}/${BIN_TYPE}")
+      #     echo "dkms_bin_path=$(echo "${BIN_TYPE}/${BIN_PKG_NAME}/${DKMS_PKG_NAME}")" >> $GITHUB_OUTPUT
+      #     echo "azure_dest=${AZURE_DEST}" >> $GITHUB_OUTPUT
+      #   env:
+      #     DEFAULT_BRANCH: ${{steps.describe.outputs.default_branch}}
+      #     BIN_TYPE: '${{ steps.describe.outputs.binary_type }}'
+      #     BIN_PKG_NAME: '${{ steps.describe.outputs.pkg_name }}'
+      #     HEAD_REF: ${{ github.head_ref || github.ref_name }}
 
-      # --- UPLOAD DKMS PACKAGE TO AZURE ---
-      - name: Upload to DKMS Package to Azure storage
-        uses: Corigine/ci-libs/github_actions/azure/azcopy_upload_sync@main
-        with:
-          connection-string: ${{ secrets.AZ_SAS_TOK }}
-          src: '${{ steps.build_dest.outputs.dkms_bin_path }}'
-          dst: '${{steps.build_dest.outputs.azure_dest}}'
+      # # --- UPLOAD DKMS PACKAGE TO AZURE ---
+      # - name: Upload to DKMS Package to Azure storage
+      #   uses: Corigine/ci-libs/github_actions/azure/azcopy_upload_sync@main
+      #   with:
+      #     connection-string: ${{ secrets.AZ_SAS_TOK }}
+      #     src: '${{ steps.build_dest.outputs.dkms_bin_path }}'
+      #     dst: '${{steps.build_dest.outputs.azure_dest}}'
 
-      - name: Clean up afterwards
-        if: always()
-        run: find -delete
+      # - name: Clean up afterwards
+      #   if: always()
+      #   run: find -delete


### PR DESCRIPTION
Update the checkout action within the workflow to use the `checkout_corigine`. This is to centralize where updates are required in the future.

The step `Add current repo to git safe directory list` is removed from the workflows since it has been moved to the checkout_corigine action.

Testing:
- package-dkms: https://github.com/Corigine/nfp-drv-kmods/actions/runs/6549371588
- ci-test-interop: https://github.com/Corigine/nfp-drv-kmods/actions/runs/6549377290