### PR TITLE
workflow: build: Add scheduled runs for builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ on:
       - 'prerelease-*'  # Prerelease build
       - 'release-*'     # Release build
       - '*.check'
+  # Schedule run every Sunday
+  schedule:
+    - cron: '0 0 * * SUN'
 
 env:
   DOWNLOAD: ".download"


### PR DESCRIPTION
Adds a scheduled run to test and verify the build for the series of commits that were merged to main within the week. This way issues can be escalated faster.